### PR TITLE
fix|service: execute keeps wrapped's name

### DIFF
--- a/opsgenie/service.py
+++ b/opsgenie/service.py
@@ -1,3 +1,4 @@
+from functools import wraps
 import platform
 
 import pkg_resources
@@ -129,7 +130,8 @@ def execute(method, url_suffix, response_cls, attachment=False):
     attachment : bool
     """
 
-    def request_wrapper(__):
+    def request_wrapper(wrapped):
+        @wraps(wrapped)
         def request_call(self, request):
             """
 


### PR DESCRIPTION
Make it easier to manipulate api entry point by name
