### PR TITLE
Fix retry_enabled=False config flag to correctly disable SDK retry logic

### DIFF
--- a/opsgenie_sdk/api_client.py
+++ b/opsgenie_sdk/api_client.py
@@ -81,7 +81,7 @@ class ApiClient(object):
                                           wait=tenacity.wait_random_exponential(multiplier=configuration.back_off,
                                                                                 max=configuration.retry_max_delay,
                                                                                 min=configuration.retry_delay),
-                                          retry=(tenacity.retry_if_result(self.is_retry_enabled) and
+                                          retry=(tenacity.retry_if_result(self.is_retry_enabled) &
                                                  ((tenacity.retry_if_exception_type(RetryableException)) |
                                                   (tenacity.retry_if_exception_type(HTTPError)))))
 
@@ -104,7 +104,7 @@ class ApiClient(object):
             self._pool.join()
             self._pool = None
 
-    def is_retry_enabled(self):
+    def is_retry_enabled(self, _):
         return self.configuration.retry_enabled
 
     @property


### PR DESCRIPTION
This is needed because the retry logic in SDK doesn't work properly :-(
(see https://github.com/opsgenie/opsgenie-python-sdk/issues/21)