### PR TITLE
Removing numpy dependency

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "python.pythonPath": "/usr/bin/python"
+}

--- a/opsgenie_sdk/api_client.py
+++ b/opsgenie_sdk/api_client.py
@@ -24,7 +24,6 @@ import uuid
 # python 2 and python 3 compatibility library
 import six
 import tenacity
-from numpy import long
 from six.moves.urllib.parse import quote
 from urllib3.exceptions import HTTPError
 

--- a/opsgenie_sdk/rest.py
+++ b/opsgenie_sdk/rest.py
@@ -23,7 +23,6 @@ import ssl
 import certifi
 # python 2 and python 3 compatibility library
 import six
-from numpy import long
 from six.moves.urllib.parse import urlencode
 from opsgenie_sdk import errors
 from .metrics import HttpMetric

--- a/opsgenie_sdk/rest.py
+++ b/opsgenie_sdk/rest.py
@@ -152,7 +152,7 @@ class RESTClientObject(object):
 
         timeout = None
         if _request_timeout:
-            if isinstance(_request_timeout, (int, ) if six.PY3 else (int, long)):  # noqa: E501,F821
+            if isinstance(_request_timeout, six.integer_types):
                 timeout = urllib3.Timeout(total=_request_timeout)
             elif (isinstance(_request_timeout, tuple) and
                   len(_request_timeout) == 2):

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,4 @@ six >= 1.10
 python_dateutil >= 2.5.3
 setuptools >= 21.0.0
 urllib3 >= 1.26.2
-numpy >= 1.16.3
 tenacity >= 5.0.4

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ VERSION = "2.1.0"
 # prerequisite: setuptools
 # http://pypi.python.org/pypi/setuptools
 
-REQUIRES = ["urllib3 >= 1.26.2", "six >= 1.10", "certifi", "python-dateutil", "numpy >= 1.16.3", "setuptools >= 21.0.0", "tenacity >= 5.0.4"]
+REQUIRES = ["urllib3 >= 1.26.2", "six >= 1.10", "certifi", "python-dateutil", "setuptools >= 21.0.0", "tenacity >= 5.0.4"]
 
 with open("README.md", "r") as fh:
     long_description = fh.read()

--- a/templates-original/rest.mustache
+++ b/templates-original/rest.mustache
@@ -133,7 +133,7 @@ class RESTClientObject(object):
 
         timeout = None
         if _request_timeout:
-            if isinstance(_request_timeout, (int, ) if six.PY3 else (int, long)):  # noqa: E501,F821
+            if isinstance(_request_timeout, six.integer_types):
                 timeout = urllib3.Timeout(total=_request_timeout)
             elif (isinstance(_request_timeout, tuple) and
                   len(_request_timeout) == 2):

--- a/templates/README_onlypackage.mustache
+++ b/templates/README_onlypackage.mustache
@@ -29,7 +29,6 @@ To be able to use it, you will need these dependencies in your own package that 
 * six >= 1.10
 * certifi
 * python-dateutil
-* numpy >= 1.16.3
 * tenacity >= 5.0.4
 {{#asyncio}}
 * aiohttp

--- a/templates/api_client.mustache
+++ b/templates/api_client.mustache
@@ -15,7 +15,6 @@ import uuid
 # python 2 and python 3 compatibility library
 import six
 import tenacity
-from numpy import long
 from six.moves.urllib.parse import quote
 from urllib3.exceptions import HTTPError
 {{#tornado}}

--- a/templates/requirements.mustache
+++ b/templates/requirements.mustache
@@ -3,5 +3,4 @@ six >= 1.10
 python_dateutil >= 2.5.3
 setuptools >= 21.0.0
 urllib3 >= 1.26.2
-numpy >= 1.16.3
 tenacity >= 5.0.4

--- a/templates/rest.mustache
+++ b/templates/rest.mustache
@@ -14,7 +14,6 @@ import ssl
 import certifi
 # python 2 and python 3 compatibility library
 import six
-from numpy import long
 from six.moves.urllib.parse import urlencode
 from {{packageName}} import errors
 from .metrics import HttpMetric

--- a/templates/rest.mustache
+++ b/templates/rest.mustache
@@ -143,7 +143,7 @@ class RESTClientObject(object):
 
         timeout = None
         if _request_timeout:
-            if isinstance(_request_timeout, (int, ) if six.PY3 else (int, long)):  # noqa: E501,F821
+            if isinstance(_request_timeout, six.integer_types):
                 timeout = urllib3.Timeout(total=_request_timeout)
             elif (isinstance(_request_timeout, tuple) and
                   len(_request_timeout) == 2):

--- a/templates/setup.mustache
+++ b/templates/setup.mustache
@@ -18,7 +18,7 @@ VERSION = "{{packageVersion}}"
 # prerequisite: setuptools
 # http://pypi.python.org/pypi/setuptools
 
-REQUIRES = ["urllib3 >= 1.26.2", "six >= 1.10", "certifi", "python-dateutil", "numpy >= 1.16.3", "setuptools >= 21.0.0", "tenacity >= 5.0.4"]
+REQUIRES = ["urllib3 >= 1.26.2", "six >= 1.10", "certifi", "python-dateutil", "setuptools >= 21.0.0", "tenacity >= 5.0.4"]
 {{#asyncio}}
 REQUIRES.append("aiohttp >= 3.0.0")
 {{/asyncio}}


### PR DESCRIPTION
Numpy's a very heavy dependency for a number type check, this removes it and uses the features in `six`.