### PR TITLE
Fix deprecated tenacity call

### DIFF
--- a/opsgenie_sdk/api_client.py
+++ b/opsgenie_sdk/api_client.py
@@ -193,13 +193,13 @@ class ApiClient(object):
 
         # perform request and return response
         try:
-            response_data = self.retrying.call(fn=self.request, method=method, url=url,
-                                               query_params=query_params,
-                                               headers=header_params,
-                                               post_params=post_params,
-                                               body=body,
-                                               _preload_content=_preload_content,
-                                               _request_timeout=_request_timeout)
+            response_data = self.retrying(fn=self.request, method=method, url=url,
+                                          query_params=query_params,
+                                          headers=header_params,
+                                          post_params=post_params,
+                                          body=body,
+                                          _preload_content=_preload_content,
+                                          _request_timeout=_request_timeout)
         except Exception as exception:
             self._sdk_request_details = {
                 "query_params": query_params,


### PR DESCRIPTION
Since tenacity 6.0.0, `tenacity.Retrying.call` is deprecated and generates warning messages. Instead one should be calling the `Retrying` instance itself: `retrying()`. https://github.com/jd/tenacity/pull/253

This new recommended behavior was also previously supported (no breaking change).